### PR TITLE
Preview layouts with values by using design-time layout attributes.

### DIFF
--- a/studio/app/src/main/res/layout-land/statistics.xml
+++ b/studio/app/src/main/res/layout-land/statistics.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical">
@@ -24,7 +25,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_distance" />
 
-                <TextView android:id="@+id/stat_distance" />
+                <TextView
+                    android:id="@+id/stat_distance"
+                    tools:text="2.72 km" />
             </TableRow>
 
             <TableRow
@@ -35,7 +38,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_overallaveragespeed" />
 
-                <TextView android:id="@+id/stat_overallaveragespeed" />
+                <TextView
+                    android:id="@+id/stat_overallaveragespeed"
+                    tools:text="3.27 km/h" />
             </TableRow>
 
             <TableRow
@@ -46,7 +51,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_averagespeed" />
 
-                <TextView android:id="@+id/stat_averagespeed" />
+                <TextView
+                    android:id="@+id/stat_averagespeed"
+                    tools:text="3.27 km/h" />
             </TableRow>
 
             <TableRow
@@ -57,7 +64,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_maximumspeed" />
 
-                <TextView android:id="@+id/stat_maximumspeed" />
+                <TextView
+                    android:id="@+id/stat_maximumspeed"
+                    tools:text="22.50 km/h" />
             </TableRow>
 
             <TableRow
@@ -68,7 +77,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_waypoints" />
 
-                <TextView android:id="@+id/stat_waypoints" />
+                <TextView
+                    android:id="@+id/stat_waypoints"
+                    tools:text="269" />
             </TableRow>
         </TableLayout>
 
@@ -86,7 +97,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_starttime" />
 
-                <nl.sogeti.android.gpstracker.util.DateView android:id="@+id/stat_starttime" />
+                <nl.sogeti.android.gpstracker.util.DateView
+                    android:id="@+id/stat_starttime"
+                    tools:text="15:10 February 29, 2016" />
             </TableRow>
 
             <TableRow
@@ -97,7 +110,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_endtime" />
 
-                <nl.sogeti.android.gpstracker.util.DateView android:id="@+id/stat_endtime" />
+                <nl.sogeti.android.gpstracker.util.DateView
+                    android:id="@+id/stat_endtime"
+                    tools:text="16:00 February 29, 2016" />
             </TableRow>
             <!--          <TableRow -->
             <!--             android:layout_width="wrap_content" -->
@@ -127,7 +142,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_elapsedtime" />
 
-                <TextView android:id="@+id/stat_elapsedtime" />
+                <TextView
+                    android:id="@+id/stat_elapsedtime"
+                    tools:text="0h:49m:54s" />
             </TableRow>
 
             <TableRow
@@ -138,7 +155,9 @@
                     android:paddingRight="10dp"
                     android:text="@string/stat_ascension" />
 
-                <TextView android:id="@+id/stat_ascension" />
+                <TextView
+                    android:id="@+id/stat_ascension"
+                    tools:text="20 meter" />
             </TableRow>
 
         </TableLayout>

--- a/studio/app/src/main/res/layout/contrib.xml
+++ b/studio/app/src/main/res/layout/contrib.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
@@ -8,5 +9,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:autoLink="web|email"
-        android:linksClickable="true" />
+        android:linksClickable="true"
+        tools:text="@string/dialog_contrib_message" />
+
 </ScrollView>

--- a/studio/app/src/main/res/layout/fragment_about.xml
+++ b/studio/app/src/main/res/layout/fragment_about.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -9,7 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
-        android:layout_weight="0" />
+        android:layout_weight="0"
+        tools:text="Version 1.3.5 build 123"/>
 
     <WebView
         android:id="@+id/fragment_about_webview"

--- a/studio/app/src/main/res/layout/map.xml
+++ b/studio/app/src/main/res/layout/map.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mapScreen"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
@@ -59,7 +60,9 @@
         android:layout_marginTop="5dp"
         android:background="#80aaaaaa"
         android:textColor="#000000"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:text="22km/h"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/speedview01"
@@ -71,7 +74,9 @@
         android:layout_marginTop="45dp"
         android:background="#80aaaaaa"
         android:textColor="#000000"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:text="17 km/h"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/speedview02"
@@ -83,7 +88,9 @@
         android:layout_marginTop="100dp"
         android:background="#80aaaaaa"
         android:textColor="#ff000000"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:text="13 km/h"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/speedview03"
@@ -95,7 +102,9 @@
         android:layout_marginTop="150dp"
         android:background="#80aaaaaa"
         android:textColor="#ff000000"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:text="9 km/h"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/speedview04"
@@ -107,7 +116,9 @@
         android:layout_marginTop="200dp"
         android:background="#80aaaaaa"
         android:textColor="#ff000000"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:text="4 km/h"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/speedview05"
@@ -119,7 +130,9 @@
         android:layout_marginTop="250dp"
         android:background="#80aaaaaa"
         android:textColor="#ff000000"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:text="0 km/h"
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/speedbar"
@@ -130,7 +143,8 @@
         android:layout_marginRight="10dp"
         android:layout_marginTop="10dp"
         android:src="@drawable/speedindexbar"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:visibility="visible" />
 
     <include layout="@layout/toolbar" />
 

--- a/studio/app/src/main/res/layout/section_header.xml
+++ b/studio/app/src/main/res/layout/section_header.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/listitem_name"
     style="?android:attr/listSeparatorTextViewStyle"
     android:layout_width="fill_parent"
@@ -8,4 +9,5 @@
     android:gravity="center"
     android:paddingLeft="6dip"
     android:paddingRight="6dip"
-    android:textAppearance="?android:attr/textAppearanceMedium" />
+    android:textAppearance="?android:attr/textAppearanceMedium"
+    tools:text="Local" />

--- a/studio/app/src/main/res/layout/sharedialog.xml
+++ b/studio/app/src/main/res/layout/sharedialog.xml
@@ -1,4 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical">
@@ -71,7 +72,8 @@
                 android:layout_below="@+id/TextView4"
                 android:clickable="true"
                 android:inputType="textAutoCorrect"
-                android:singleLine="true" />
+                android:singleLine="true"
+                tools:text="Track 2016-02-29 15:10" />
 
             <ProgressBar
                 android:id="@+id/tweet_progress"
@@ -91,7 +93,7 @@
                 android:inputType="textAutoCorrect"
                 android:maxLength="140"
                 android:maxLines="3"
-                android:text="" />
+                tools:text="@string/tweettext" />
 
             <ImageView
                 android:id="@+id/imageView"

--- a/studio/app/src/main/res/layout/statistics.xml
+++ b/studio/app/src/main/res/layout/statistics.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -19,7 +20,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_distance" />
 
-            <TextView android:id="@+id/stat_distance" />
+            <TextView
+                android:id="@+id/stat_distance"
+                tools:text="2.72 km" />
         </TableRow>
 
         <TableRow
@@ -30,7 +33,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_overallaveragespeed" />
 
-            <TextView android:id="@+id/stat_overallaveragespeed" />
+            <TextView
+                android:id="@+id/stat_overallaveragespeed"
+                tools:text="3.27 km/h" />
         </TableRow>
 
         <TableRow
@@ -41,7 +46,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_averagespeed" />
 
-            <TextView android:id="@+id/stat_averagespeed" />
+            <TextView
+                android:id="@+id/stat_averagespeed"
+                tools:text="3.27 km/h" />
         </TableRow>
 
         <TableRow
@@ -52,7 +59,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_maximumspeed" />
 
-            <TextView android:id="@+id/stat_maximumspeed" />
+            <TextView
+                android:id="@+id/stat_maximumspeed"
+                tools:text="22.50 km/h" />
         </TableRow>
 
         <TableRow
@@ -63,7 +72,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_waypoints" />
 
-            <TextView android:id="@+id/stat_waypoints" />
+            <TextView
+                android:id="@+id/stat_waypoints"
+                tools:text="269" />
         </TableRow>
 
         <TableRow
@@ -74,7 +85,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_starttime" />
 
-            <nl.sogeti.android.gpstracker.util.DateView android:id="@+id/stat_starttime" />
+            <nl.sogeti.android.gpstracker.util.DateView
+                android:id="@+id/stat_starttime"
+                tools:text="15:10 February 29, 2016" />
         </TableRow>
 
         <TableRow
@@ -85,7 +98,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_endtime" />
 
-            <nl.sogeti.android.gpstracker.util.DateView android:id="@+id/stat_endtime" />
+            <nl.sogeti.android.gpstracker.util.DateView
+                android:id="@+id/stat_endtime"
+                tools:text="16:00 February 29, 2016" />
         </TableRow>
 
         <TableRow
@@ -96,7 +111,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_elapsedtime" />
 
-            <TextView android:id="@+id/stat_elapsedtime" />
+            <TextView
+                android:id="@+id/stat_elapsedtime"
+                tools:text="0h:49m:54s" />
         </TableRow>
 
         <TableRow
@@ -107,7 +124,9 @@
                 android:paddingRight="15dp"
                 android:text="@string/stat_ascension" />
 
-            <TextView android:id="@+id/stat_ascension" />
+            <TextView
+                android:id="@+id/stat_ascension"
+                tools:text="20 meter" />
         </TableRow>
 
         <nl.sogeti.android.gpstracker.actions.utils.ViewFlipper

--- a/studio/app/src/main/res/layout/trackitem.xml
+++ b/studio/app/src/main/res/layout/trackitem.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content">
 
@@ -10,7 +11,8 @@
         android:layout_alignParentTop="true"
         android:paddingLeft="6dip"
         android:paddingRight="6dip"
-        android:textAppearance="?android:attr/textAppearanceLarge" />
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        tools:text="Track 2016-02-29 15:10" />
 
     <TextView
         android:id="@+id/from_textview"
@@ -28,7 +30,8 @@
         android:layout_below="@+id/listitem_name"
         android:layout_toRightOf="@+id/from_textview"
         android:paddingLeft="3dip"
-        android:paddingTop="3dip" />
+        android:paddingTop="3dip"
+        tools:text="15:10 February 29, 2016" />
 
     <CheckBox
         android:id="@+id/bcSyncedCheckBox"
@@ -40,7 +43,8 @@
         android:focusable="false"
         android:paddingLeft="3dip"
         android:text=""
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:visibility="visible" />
 
     <ProgressBar
         android:id="@+id/bcExportProgress"
@@ -51,6 +55,7 @@
         android:layout_centerVertical="true"
         android:max="10000"
         android:paddingLeft="3dip"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        tools:visibility="visible" />
 
 </RelativeLayout>

--- a/studio/app/src/main/res/layout/tracklist.xml
+++ b/studio/app/src/main/res/layout/tracklist.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical">
@@ -11,7 +12,8 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:choiceMode="singleChoice"
-        android:drawSelectorOnTop="true" />
+        android:drawSelectorOnTop="true"
+        tools:listitem="@layout/trackitem" />
 
     <TextView
         android:id="@+id/android:empty"

--- a/studio/app/src/main/res/values/strings.xml
+++ b/studio/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" tools:ignore="MissingTranslation">
     <string name="app_name">Open GPS Tracker</string>
 
     <!-- Dialogs -->
@@ -70,7 +70,12 @@
     <string name="error_filename"> reason: Incorrect filename</string>
     <string name="error_buildxml"> reason: Error building XML</string>
     <string name="error_writesdcard"> reason: Error writing to SD card</string>
-    <string name="tweettext">%1$s: Traveled %2$s with an average speed of %3$s during %4$s #opengpstracker</string>
+    <string name="tweettext">
+        <xliff:g example="Track 2016-02-29 15:10" id="trackName">%1$s:</xliff:g> Traveled
+        <xliff:g example="2.72 km" id="distance">%2$s</xliff:g> with an average speed of
+        <xliff:g example="3.27 km/h" id="averageSpeed">%3$s</xliff:g> during
+        <xliff:g example="0h:49m:54s" id="duration">%4$s</xliff:g> #opengpstracker
+    </string>
     <string name="error_importgpx_xml">Failed reading the XML during import.</string>
     <string name="error_importgpx_io">Failed reading the file during import.</string>
     <string name="time_and_speed">At %1$s going %2$s</string>


### PR DESCRIPTION
I introduced [design-time layout attributes](http://tools.android.com/tips/layout-designtime-attributes) in a few places to make it easier to understand and maintain the layouts. Please note that the text field values are not compiled into the APK.

### Track list before and after

![before](https://cloud.githubusercontent.com/assets/144518/12222376/e6e7f622-b7ba-11e5-8e4d-c28ce76c5827.png) ![after](https://cloud.githubusercontent.com/assets/144518/12222377/e6e86288-b7ba-11e5-887e-000cbe7269a7.png)
