### PR TITLE
Apply design guidelines for alert dialog margin.

### DIFF
--- a/studio/app/src/main/res/layout-land/graphtype.xml
+++ b/studio/app/src/main/res/layout-land/graphtype.xml
@@ -3,7 +3,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/studio/app/src/main/res/layout-land/insertnote.xml
+++ b/studio/app/src/main/res/layout-land/insertnote.xml
@@ -3,7 +3,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/studio/app/src/main/res/layout-land/layerdialog.xml
+++ b/studio/app/src/main/res/layout-land/layerdialog.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/studio/app/src/main/res/layout-land/logcontrol.xml
+++ b/studio/app/src/main/res/layout-land/logcontrol.xml
@@ -3,7 +3,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/studio/app/src/main/res/layout/graphtype.xml
+++ b/studio/app/src/main/res/layout/graphtype.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <Button
         android:id="@+id/graphtype_timespeed"

--- a/studio/app/src/main/res/layout/insertnote.xml
+++ b/studio/app/src/main/res/layout/insertnote.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <Button
         android:id="@+id/noteinsert_name"

--- a/studio/app/src/main/res/layout/layerdialog.xml
+++ b/studio/app/src/main/res/layout/layerdialog.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <LinearLayout
         android:layout_width="fill_parent"

--- a/studio/app/src/main/res/layout/logcontrol.xml
+++ b/studio/app/src/main/res/layout/logcontrol.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="@dimen/alert_dialog_content_margin">
 
     <Button
         android:id="@+id/logcontrol_start"

--- a/studio/app/src/main/res/values/dimens.xml
+++ b/studio/app/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="widget_margin">8dp</dimen>
+    <!-- See: https://www.google.de/design/spec/components/dialogs.html#dialogs-specs -->
+    <dimen name="alert_dialog_content_margin">24dp</dimen>
 </resources>


### PR DESCRIPTION
I added margin around the content of dialogs. By this, the content left aligns with the headline of the dialog as described in the [Material design specs](https://www.google.de/design/spec/components/dialogs.html#dialogs-specs).

### Overlays dialog before and after

![Overlays dialog before](https://cloud.githubusercontent.com/assets/144518/12536605/771cb7c4-c2aa-11e5-8f3d-f37e28dde836.png) ![Overlays dialog after](https://cloud.githubusercontent.com/assets/144518/12536604/76ef331c-c2aa-11e5-97c3-47594e634a92.png)

---

I am happy to *rebase* this branch onto current `develop` before *merging* to enable (a) a clean *merge commit* without conflicts and (b) a linear version history to allow painless debugging. Just let me know and I will *force push* the branch.